### PR TITLE
變更「夾」讀音的詞頻

### DIFF
--- a/terra_pinyin.dict.yaml
+++ b/terra_pinyin.dict.yaml
@@ -10503,8 +10503,8 @@ min_phrase_weight: 100
 夻	hua4
 夼	kuang3
 夽	yun3
-夾	jia1	95%
-夾	jia2	5%
+夾	jia1	50%
+夾	jia2	50%
 夿	ba1
 奀	en1
 奁	lian2


### PR DESCRIPTION
變更「夾」讀音的詞頻	
jia1 95%變更爲50%
jia2 5% 變更爲50%

說明 臺灣常用的是 jia2 讀音
爲了參與自動組詞而將詞頻改爲 50%

![image](https://user-images.githubusercontent.com/9501406/37871657-c3d6f8fa-3025-11e8-9d60-335311ba1078.png)
