### PR TITLE
fix auto uen to un correction that was not working

### DIFF
--- a/terra_pinyin.schema.yaml
+++ b/terra_pinyin.schema.yaml
@@ -59,7 +59,7 @@ speller:
     - abbrev/^([zcs]h).+$/$1/
     - derive/^([nl])ve/$1ue/
     - derive/^([jqxy])u/$1v/
-    - derive/un$/uen/
+    - derive/([dtnlgkhrzcs])un/$1uen/
     - derive/ui/uei/
     - derive/iu/iou/
     - derive/ao/oa/
@@ -80,6 +80,7 @@ translator:
   preedit_format:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
+    - xform/([nl])üen/$1uen/
     - xform/([jqxy])v/$1u/
     - xform/eh/ê/
     - 'xform ([aeiou])(ng?|r)([-;/<,>\\]) $1$3$2'


### PR DESCRIPTION
The original `speller/algebra` rule `derive/un$/uen/` was not working due to the unnecessary `$`. Removing the `$` allows the autocorrection to work in intended cases, but also in the unwanted cases of `un` after `[jqx]`; therefore the intended cases of `un` after `[dtnlgkhrzcs]` (this also covers `zh`, `ch`, `sh`) must be explicitly specified.
Under `translator/preedit_format`, a new rule `xform/([nl])üen/$1uen/` is added after `xform/([nl])ue/$1üe/` so that in the preedit `[nl]ue` appears as `[nl]üe` but `[nl]uen` is not changed.