### PR TITLE
为单字“褪”添加 tui4 读音

### DIFF
--- a/terra_pinyin.dict.yaml
+++ b/terra_pinyin.dict.yaml
@@ -24856,7 +24856,8 @@ min_phrase_weight: 100
 褨	suo3
 褩	ban1
 褩	pan2
-褪	tun4
+褪	tun4	50%
+褪	tui4	50%
 褫	chi3
 褬	sang3
 褭	niao3


### PR DESCRIPTION
下方的词语例如“褪色”等均有 tui4 音，但单字仅有 tun4 音，遂补全。