### PR TITLE
Correct pronunciation for '曝' in dictionary

### DIFF
--- a/terra_pinyin.dict.yaml
+++ b/terra_pinyin.dict.yaml
@@ -14693,7 +14693,7 @@ min_phrase_weight: 100
 曚	meng2
 曛	xun1
 曜	yao4
-曝	pu4
+曝	bao4
 曞	li4
 曟	chen2
 曠	kuang4
@@ -71412,8 +71412,7 @@ min_phrase_weight: 100
 曙色	shu4 se4
 曛黑	xun1 he4
 曝光表	bao4 guang1 biao3
-曝光表	pu4 guang1 biao3
-曝露	pu4 lu4
+曝露	bao4 lu4
 曠世之度	kuang4 shi4 zhi1 du4
 曠世無匹	kuang4 shi4 wu2 pi3
 曠度	kuang4 du4

--- a/terra_pinyin.dict.yaml
+++ b/terra_pinyin.dict.yaml
@@ -14694,6 +14694,7 @@ min_phrase_weight: 100
 曛	xun1
 曜	yao4
 曝	bao4
+曝	pu4
 曞	li4
 曟	chen2
 曠	kuang4
@@ -71412,7 +71413,9 @@ min_phrase_weight: 100
 曙色	shu4 se4
 曛黑	xun1 he4
 曝光表	bao4 guang1 biao3
+曝光表	pu4 guang1 biao3
 曝露	bao4 lu4
+曝露	pu4 lu4
 曠世之度	kuang4 shi4 zhi1 du4
 曠世無匹	kuang4 shi4 wu2 pi3
 曠度	kuang4 du4


### PR DESCRIPTION
在简体现代汉语中，'曝'字的唯一读音是bao4, 没有人读pu4。原方案中无法通过bao4输入'曝'字。